### PR TITLE
Guard against missing 'time' in hourly forecast rows

### DIFF
--- a/pyweatherflow_forecast/wffcst_lib.py
+++ b/pyweatherflow_forecast/wffcst_lib.py
@@ -368,7 +368,12 @@ def _get_forecast(api_result: dict, forecast_hours: int) -> list[WeatherFlowFore
         if _hour_counter > forecast_hours:
             break
 
-        timestamp = item["time"]
+        timestamp = item.get("time", None)
+        if timestamp is None:
+            # WeatherFlow occasionally omits 'time' on an hourly forecast row.
+            # Skip that row instead of raising KeyError, which would fail the
+            # entire update and take all entities offline until the next poll.
+            continue
         valid_time = datetime.datetime.fromtimestamp(timestamp)
         condition = item.get("conditions", None)
         icon = ICON_LIST.get(item["icon"], "exceptional")


### PR DESCRIPTION
### What this fixes

Closes #34.

The hourly forecast loop in `_get_forecast()` read the row timestamp with a hard subscript:

```python
timestamp = item["time"]
```

When the WeatherFlow `better_forecast` API intermittently returns an hourly row without `time`, this raises `KeyError: 'time'`. The coordinator wraps it as `Update failed: 'time'` and the whole update fails, taking every entity offline until a later poll recovers. It's intermittent because the field is usually present — a good response carries `time` on every hourly row.

### The change

Guard the lookup and skip a row that has no timestamp, mirroring how `_get_forecast_current()` already does `item.get("time", None)`:

```python
timestamp = item.get("time", None)
if timestamp is None:
    continue
valid_time = datetime.datetime.fromtimestamp(timestamp)
```

The daily loop is unaffected (it uses `item["day_start_local"]`), and current conditions was already guarded. This is the same shape as the earlier missing-field fixes (`feels_like`, `precip`, `brightness`, `air_temperature`).

I couldn't reproduce the missing-`time` payload on demand (the field is present in live responses right now), so this is verified by code inspection against a live `better_forecast` payload rather than by a captured failing payload.

---
*Authored by Claude (claude-opus-4-8) on behalf of the account owner. The diagnosis came from operating the owner's Home Assistant via the HA MCP and comparing the library source against a live `better_forecast` payload; the patch mirrors the existing guard in `_get_forecast_current()`. Lint wasn't run locally (ruff unavailable in the environment) — relying on CI. Opened with the owner's review and authorization.*
